### PR TITLE
Gtk3: Fix wrong filename of scrollebar

### DIFF
--- a/Breeze-dark-gtk/gtk-3.0/gtk.css
+++ b/Breeze-dark-gtk/gtk-3.0/gtk.css
@@ -2251,7 +2251,7 @@ column-header .titlebar .button.titlebutton,
       border-style: solid;
       border-color: transparent; }
     .scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal .slider {
-      border-image: -gtk-scaled(url("assets/scrollbar-slider-overlay-horizontal-dark.png"), url("assets/scrollbar-slider-overlay-horizontal-dark@2.png")) 4 6 4 6/4px 6px 4px 6px stretch;
+      border-image: -gtk-scaled(url("assets/scrollbar-slider-horizontal-overlay-dark.png"), url("assets/scrollbar-slider-horizontal-overlay-dark@2.png")) 4 6 4 6/4px 6px 4px 6px stretch;
       border-radius: 0;
       border-width: 4px 6px 4px 6px;
       border-style: solid;

--- a/Breeze-gtk/gtk-3.0/_common.scss
+++ b/Breeze-gtk/gtk-3.0/_common.scss
@@ -1981,7 +1981,7 @@ column-header.button.dnd { // for treeview-like derive widgets
 	-GtkScrollbar-has-forward-stepper: false;
 
     .slider { @include _border(scrollbar-slider-overlay, $prefix:assets, $radius: 0, $width: 5px 4px 5px 4px, $image-width: 6 4 6 4 / 6px 4px 6px 4px); }
-    &.horizontal .slider { @include _border(scrollbar-slider-overlay-horizontal, $prefix:assets, $radius: 0, $width: 4px 6px 4px 6px, $image-width: 4 6 4 6 / 4px 6px 4px 6px); }
+    &.horizontal .slider { @include _border(scrollbar-slider-horizontal-overlay, $prefix:assets, $radius: 0, $width: 4px 6px 4px 6px, $image-width: 4 6 4 6 / 4px 6px 4px 6px); }
 
     .trough {
       border: none;

--- a/Breeze-gtk/gtk-3.0/gtk-dark.css
+++ b/Breeze-gtk/gtk-3.0/gtk-dark.css
@@ -2242,7 +2242,7 @@ column-header .titlebar .button.titlebutton,
       border-style: solid;
       border-color: transparent; }
     .scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal .slider {
-      border-image: -gtk-scaled(url("assets/scrollbar-slider-overlay-horizontal-dark.png"), url("assets/scrollbar-slider-overlay-horizontal-dark@2.png")) 4 6 4 6/4px 6px 4px 6px stretch;
+      border-image: -gtk-scaled(url("assets/scrollbar-slider-horizontal-overlay-dark.png"), url("assets/scrollbar-slider-horizontal-overlay-dark@2.png")) 4 6 4 6/4px 6px 4px 6px stretch;
       border-radius: 0;
       border-width: 4px 6px 4px 6px;
       border-style: solid;

--- a/Breeze-gtk/gtk-3.0/gtk.css
+++ b/Breeze-gtk/gtk-3.0/gtk.css
@@ -2254,7 +2254,7 @@ column-header .titlebar .button.titlebutton,
       border-style: solid;
       border-color: transparent; }
     .scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal .slider {
-      border-image: -gtk-scaled(url("assets/scrollbar-slider-overlay-horizontal.png"), url("assets/scrollbar-slider-overlay-horizontal@2.png")) 4 6 4 6/4px 6px 4px 6px stretch;
+      border-image: -gtk-scaled(url("assets/scrollbar-slider-horizontal-overlay.png"), url("assets/scrollbar-slider-horizontal-overlay@2.png")) 4 6 4 6/4px 6px 4px 6px stretch;
       border-radius: 0;
       border-width: 4px 6px 4px 6px;
       border-style: solid;


### PR DESCRIPTION
`(gtk3-demo:5797): Gtk-WARNING **: Error loading image 'file:///usr/share/themes/Breeze/gtk-3.0/assets/scrollbar-slider-overlay-horizontal.png': Error opening file: No such file or directory`

the image file in `assets` name `scrollbar-slider-horizontal-overlay.png` but in css file was `scrollbar-slider-horizontal-overlay.png`.
