### PR TITLE
Use 1px padding on titlebuttons

### DIFF
--- a/Breeze-dark-gtk/gtk-3.18/gtk.css
+++ b/Breeze-dark-gtk/gtk-3.18/gtk.css
@@ -2832,7 +2832,7 @@ column-header .button, column-header .button:hover, column-header .button:active
     transition: none; }
   .header-bar .button.titlebutton.close,
   .titlebar .button.titlebutton.close {
-    padding: 6px 1px;
+    padding: 1px;
     color: transparent;
     border-image: none;
     box-shadow: none;
@@ -2856,7 +2856,7 @@ column-header .button, column-header .button:hover, column-header .button:active
     background-image: -gtk-scaled(url("../assets/titlebutton-close-backdrop.png"), url("../assets/titlebutton-close-backdrop@2.png")); }
   .header-bar .button.titlebutton.maximize,
   .titlebar .button.titlebutton.maximize {
-    padding: 6px 1px;
+    padding: 1px;
     color: transparent;
     border-image: none;
     box-shadow: none;
@@ -2880,7 +2880,7 @@ column-header .button, column-header .button:hover, column-header .button:active
     background-image: -gtk-scaled(url("../assets/titlebutton-maximize-backdrop.png"), url("../assets/titlebutton-maximize-backdrop@2.png")); }
   .header-bar .button.titlebutton.minimize,
   .titlebar .button.titlebutton.minimize {
-    padding: 6px 1px;
+    padding: 1px;
     color: transparent;
     border-image: none;
     box-shadow: none;
@@ -2905,7 +2905,7 @@ column-header .button, column-header .button:hover, column-header .button:active
 
 .maximized .header-bar .button.titlebutton.maximize, .maximized
 .titlebar .button.titlebutton.maximize {
-  padding: 6px 1px;
+  padding: 1px;
   color: transparent;
   border-image: none;
   box-shadow: none;

--- a/Breeze-dark-gtk/gtk-3.20/gtk.css
+++ b/Breeze-dark-gtk/gtk-3.20/gtk.css
@@ -3652,7 +3652,7 @@ decoration {
 
 headerbar.default-decoration button.titlebutton,
 .titlebar.default-decoration button.titlebutton {
-  padding: 6px 1px;
+  padding: 1px;
   min-height: 18px;
   min-width: 18px;
   margin: 0; }
@@ -3668,7 +3668,7 @@ headerbar button.titlebutton,
     transition: none; }
   headerbar button.titlebutton.close,
   .titlebar button.titlebutton.close {
-    padding: 6px 1px;
+    padding: 1px;
     color: transparent;
     border-image: none;
     box-shadow: none;
@@ -3692,7 +3692,7 @@ headerbar button.titlebutton,
     background-image: -gtk-scaled(url("../assets/titlebutton-close-backdrop.png"), url("../assets/titlebutton-close-backdrop@2.png")); }
   headerbar button.titlebutton.maximize,
   .titlebar button.titlebutton.maximize {
-    padding: 6px 1px;
+    padding: 1px;
     color: transparent;
     border-image: none;
     box-shadow: none;
@@ -3716,7 +3716,7 @@ headerbar button.titlebutton,
     background-image: -gtk-scaled(url("../assets/titlebutton-maximize-backdrop.png"), url("../assets/titlebutton-maximize-backdrop@2.png")); }
   headerbar button.titlebutton.minimize,
   .titlebar button.titlebutton.minimize {
-    padding: 6px 1px;
+    padding: 1px;
     color: transparent;
     border-image: none;
     box-shadow: none;
@@ -3740,7 +3740,7 @@ headerbar button.titlebutton,
     background-image: -gtk-scaled(url("../assets/titlebutton-minimize-backdrop.png"), url("../assets/titlebutton-minimize-backdrop@2.png")); }
 .maximized headerbar button.titlebutton.maximize, .maximized
 .titlebar button.titlebutton.maximize {
-  padding: 6px 1px;
+  padding: 1px;
   color: transparent;
   border-image: none;
   box-shadow: none;

--- a/Breeze-gtk/gtk-3.18/gtk.css
+++ b/Breeze-gtk/gtk-3.18/gtk.css
@@ -2832,7 +2832,7 @@ column-header .button, column-header .button:hover, column-header .button:active
     transition: none; }
   .header-bar .button.titlebutton.close,
   .titlebar .button.titlebutton.close {
-    padding: 6px 1px;
+    padding: 1px;
     color: transparent;
     border-image: none;
     box-shadow: none;
@@ -2856,7 +2856,7 @@ column-header .button, column-header .button:hover, column-header .button:active
     background-image: -gtk-scaled(url("../assets/titlebutton-close-backdrop.png"), url("../assets/titlebutton-close-backdrop@2.png")); }
   .header-bar .button.titlebutton.maximize,
   .titlebar .button.titlebutton.maximize {
-    padding: 6px 1px;
+    padding: 1px;
     color: transparent;
     border-image: none;
     box-shadow: none;
@@ -2880,7 +2880,7 @@ column-header .button, column-header .button:hover, column-header .button:active
     background-image: -gtk-scaled(url("../assets/titlebutton-maximize-backdrop.png"), url("../assets/titlebutton-maximize-backdrop@2.png")); }
   .header-bar .button.titlebutton.minimize,
   .titlebar .button.titlebutton.minimize {
-    padding: 6px 1px;
+    padding: 1px;
     color: transparent;
     border-image: none;
     box-shadow: none;
@@ -2905,7 +2905,7 @@ column-header .button, column-header .button:hover, column-header .button:active
 
 .maximized .header-bar .button.titlebutton.maximize, .maximized
 .titlebar .button.titlebutton.maximize {
-  padding: 6px 1px;
+  padding: 1px;
   color: transparent;
   border-image: none;
   box-shadow: none;

--- a/Breeze-gtk/gtk-3.20/gtk.css
+++ b/Breeze-gtk/gtk-3.20/gtk.css
@@ -3637,7 +3637,7 @@ decoration {
 
 headerbar.default-decoration button.titlebutton,
 .titlebar.default-decoration button.titlebutton {
-  padding: 6px 1px;
+  padding: 1px;
   min-height: 18px;
   min-width: 18px;
   margin: 0; }
@@ -3653,7 +3653,7 @@ headerbar button.titlebutton,
     transition: none; }
   headerbar button.titlebutton.close,
   .titlebar button.titlebutton.close {
-    padding: 6px 1px;
+    padding: 1px;
     color: transparent;
     border-image: none;
     box-shadow: none;
@@ -3677,7 +3677,7 @@ headerbar button.titlebutton,
     background-image: -gtk-scaled(url("../assets/titlebutton-close-backdrop.png"), url("../assets/titlebutton-close-backdrop@2.png")); }
   headerbar button.titlebutton.maximize,
   .titlebar button.titlebutton.maximize {
-    padding: 6px 1px;
+    padding: 1px;
     color: transparent;
     border-image: none;
     box-shadow: none;
@@ -3701,7 +3701,7 @@ headerbar button.titlebutton,
     background-image: -gtk-scaled(url("../assets/titlebutton-maximize-backdrop.png"), url("../assets/titlebutton-maximize-backdrop@2.png")); }
   headerbar button.titlebutton.minimize,
   .titlebar button.titlebutton.minimize {
-    padding: 6px 1px;
+    padding: 1px;
     color: transparent;
     border-image: none;
     box-shadow: none;
@@ -3725,7 +3725,7 @@ headerbar button.titlebutton,
     background-image: -gtk-scaled(url("../assets/titlebutton-minimize-backdrop.png"), url("../assets/titlebutton-minimize-backdrop@2.png")); }
 .maximized headerbar button.titlebutton.maximize, .maximized
 .titlebar button.titlebutton.maximize {
-  padding: 6px 1px;
+  padding: 1px;
   color: transparent;
   border-image: none;
   box-shadow: none;


### PR DESCRIPTION
This patch fixes titlebutton rendering in Chromium.  The headerbar used by Breeze is the same size when a window is maximized, but Chromium uses a smaller headerbar for its tabstrip background when the browser is maximized.  When buttons won't fit, Chromium downsizes buttons.  This was happening with Breeze titlebuttons since it used 6px of padding on the top and bottom of the buttons, so the buttons appeared taller than they actually were.  This patch changes the top and bottom padding to 1px.  In native GTK apps, there's no change in appearance.