### PR TITLE
fix: treeview separator typo

### DIFF
--- a/Breeze-dark-gtk/gtk-3.18/gtk.css
+++ b/Breeze-dark-gtk/gtk-3.18/gtk.css
@@ -2714,7 +2714,7 @@ GtkTreeView.view {
         color: rgba(216, 218, 221, 0.35); }
     GtkTreeView.view:insensitive:backdrop {
       color: rgba(88, 92, 95, 0.35); }
-  GtkTreeView.view.seperator {
+  GtkTreeView.view.separator {
     color: #616569; }
   GtkTreeView.view.separator:backdrop {
     color: #616569; }

--- a/Breeze-dark-gtk/gtk-3.20/gtk.css
+++ b/Breeze-dark-gtk/gtk-3.20/gtk.css
@@ -3535,7 +3535,7 @@ treeview.view {
         color: rgba(216, 218, 221, 0.35); }
     treeview.view:disabled:backdrop {
       color: rgba(88, 92, 95, 0.35); }
-  treeview.view.seperator {
+  treeview.view.separator {
     min-height: 2px;
     color: #616569; }
   treeview.view.separator:backdrop {

--- a/Breeze-gtk/gtk-3.18/gtk.css
+++ b/Breeze-gtk/gtk-3.18/gtk.css
@@ -2714,7 +2714,7 @@ GtkTreeView.view {
         color: rgba(216, 218, 221, 0.35); }
     GtkTreeView.view:insensitive:backdrop {
       color: rgba(174, 176, 179, 0.35); }
-  GtkTreeView.view.seperator {
+  GtkTreeView.view.separator {
     color: #c0c2c4; }
   GtkTreeView.view.separator:backdrop {
     color: #c0c2c4; }

--- a/Breeze-gtk/gtk-3.20/gtk.css
+++ b/Breeze-gtk/gtk-3.20/gtk.css
@@ -3579,7 +3579,7 @@ treeview.view {
         color: @insensitive_bg_color; }
     treeview.view:disabled:backdrop {
       color: @insensitive_borders; }
-  treeview.view.seperator {
+  treeview.view.separator {
     min-height: 2px;
     color: @borders; }
   treeview.view.separator:backdrop {


### PR DESCRIPTION
Fixes a small typo with a nasty side effect of making treeviews unusable in gtk-3.0 apps:
![fix](https://user-images.githubusercontent.com/10726032/47191505-94144180-d350-11e8-993b-a65ded238d0d.png)
